### PR TITLE
Add resetZoomOnGestureEnd prop to allow it to be set to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ All `React Native Image Props` &
 | imageContainerStyle | Object | `{}` | Style object to be applied to the image container. |
 | activityIndicatorProps | Object | `{}` | Activity Indicator Props to customize the default loader. |
 | renderLoader | Function | `undefined` | Function that renders a custom loading component. Render `null` to disable loader. |
-
+| resetZoomOnGestureEnd | boolean | true | Reset zoom and snap back to initial position on gesture end. |
 
 ## Changelog
 

--- a/src/components/ImageZoom.tsx
+++ b/src/components/ImageZoom.tsx
@@ -62,6 +62,7 @@ export default function ImageZoom({
   imageContainerStyle = {},
   activityIndicatorProps = {},
   renderLoader,
+  resetZoomOnGestureEnd = true,
   ...props
 }: ImageZoomProps) {
   const panRef = useRef();
@@ -132,8 +133,10 @@ export default function ImageZoom({
       translateY.value = event.translationY;
     },
     onFinish: () => {
-      translateX.value = withTiming(0);
-      translateY.value = withTiming(0);
+      if (resetZoomOnGestureEnd) {
+        translateX.value = withTiming(0);
+        translateY.value = withTiming(0);
+      }
     },
   });
 
@@ -154,11 +157,13 @@ export default function ImageZoom({
         focalY.value = (centerY - initialFocalY.value) * (scale.value - 1);
       },
       onFinish: () => {
-        scale.value = withTiming(1);
-        focalX.value = withTiming(0);
-        focalY.value = withTiming(0);
-        initialFocalX.value = 0;
-        initialFocalY.value = 0;
+        if (resetZoomOnGestureEnd) {
+          scale.value = withTiming(1);
+          focalX.value = withTiming(0);
+          focalY.value = withTiming(0);
+          initialFocalX.value = 0;
+          initialFocalY.value = 0;
+        }
       },
     });
 

--- a/src/components/types.d.ts
+++ b/src/components/types.d.ts
@@ -100,4 +100,8 @@ export type ImageZoomProps = {
    * Render custom loader component.
    */
   renderLoader?: Function;
+    /**
+   * Reset zoom and snap back to initial position on gesture end.
+   */
+  resetZoomOnGestureEnd?: boolean
 };


### PR DESCRIPTION
## Motivation

The users of my application would like for the panning and pinching to not reset back.  Adding this flag will allow this usecase to be easily achieved.  By default, the prop will be true as to not change current default functionality.
